### PR TITLE
Allow protocol tests to run (in no_std)

### DIFF
--- a/protocol/src/constants.rs
+++ b/protocol/src/constants.rs
@@ -122,9 +122,9 @@ pub mod bincode_impl {
 
     impl TryFrom<&[u8]> for ChainAnchor {
         type Error = DecodeError;
-        fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
+        fn try_from(value: &[u8]) -> core::result::Result<Self, Self::Error> {
             let (meta, _): (ChainAnchor, _) = bincode::decode_from_slice(value, config::standard())
-                .expect("could not parse chain anchor");
+                .map_err(|_| DecodeError::OtherString("could not parse chain anchor".to_owned()))?;
             Ok(meta)
         }
     }

--- a/protocol/src/hasher.rs
+++ b/protocol/src/hasher.rs
@@ -1,3 +1,4 @@
+use crate::alloc::string::ToString;
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};
 use bitcoin::{Amount, OutPoint};

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -5,6 +5,9 @@ extern crate core;
 
 pub extern crate bitcoin;
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};
 use bitcoin::{

--- a/protocol/src/prepare.rs
+++ b/protocol/src/prepare.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use bitcoin::{
     absolute::LockTime,
     opcodes::all::OP_RETURN,

--- a/protocol/src/script.rs
+++ b/protocol/src/script.rs
@@ -1,4 +1,5 @@
 use alloc::collections::btree_map::BTreeMap;
+use alloc::vec::Vec;
 
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};

--- a/protocol/src/sname.rs
+++ b/protocol/src/sname.rs
@@ -1,6 +1,7 @@
 use alloc::{string::String, vec::Vec};
 use core::{
     fmt::{Display, Formatter},
+    result,
     str::FromStr,
 };
 
@@ -130,7 +131,7 @@ pub trait NameLike {
 impl FromStr for SName {
     type Err = crate::errors::Error;
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> result::Result<Self, Self::Err> {
         s.try_into()
     }
 }
@@ -138,7 +139,7 @@ impl FromStr for SName {
 impl<const N: usize> TryFrom<&[u8; N]> for SName {
     type Error = crate::errors::Error;
 
-    fn try_from(value: &[u8; N]) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: &[u8; N]) -> result::Result<Self, Self::Error> {
         value.as_slice().try_into()
     }
 }
@@ -146,7 +147,7 @@ impl<const N: usize> TryFrom<&[u8; N]> for SName {
 impl TryFrom<&Vec<u8>> for SName {
     type Error = crate::errors::Error;
 
-    fn try_from(value: &Vec<u8>) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: &Vec<u8>) -> result::Result<Self, Self::Error> {
         value.as_slice().try_into()
     }
 }
@@ -154,7 +155,7 @@ impl TryFrom<&Vec<u8>> for SName {
 impl core::convert::TryFrom<&[u8]> for SName {
     type Error = crate::errors::Error;
 
-    fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: &[u8]) -> result::Result<Self, Self::Error> {
         let name_ref: SNameRef = value.try_into()?;
         Ok(name_ref.to_owned())
     }
@@ -193,7 +194,7 @@ impl<'a> core::convert::TryFrom<&'a [u8]> for SNameRef<'a> {
 impl TryFrom<String> for SName {
     type Error = crate::errors::Error;
 
-    fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: String) -> result::Result<Self, Self::Error> {
         value.as_str().try_into()
     }
 }
@@ -201,7 +202,7 @@ impl TryFrom<String> for SName {
 impl TryFrom<&str> for SName {
     type Error = crate::errors::Error;
 
-    fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: &str) -> result::Result<Self, Self::Error> {
         let (subspace, space) = value
             .split_once('@')
             .ok_or(Error::Name(NameErrorKind::MalformedName))?;

--- a/protocol/src/validate.rs
+++ b/protocol/src/validate.rs
@@ -1,5 +1,6 @@
+use alloc::collections::btree_map::BTreeMap;
+use alloc::vec;
 use alloc::vec::Vec;
-use std::collections::BTreeMap;
 
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};


### PR DESCRIPTION
In this PR, we fix some usages of `std` to enable tests for `protocol` to run.

Here's a sample test run:
<img width="675" alt="image" src="https://github.com/user-attachments/assets/616ce754-fc03-425c-b1c6-8529e0b9c83f">
