### PR TITLE
Simplify some RPC methods

### DIFF
--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -102,14 +102,14 @@ pub trait Rpc {
     #[method(name = "getspaceowner")]
     async fn get_space_owner(&self, space: String) -> Result<Option<OutPoint>, ErrorObjectOwned>;
 
+    #[method(name = "getspaceout")]
+    async fn get_spaceout(&self, outpoint: OutPoint) -> Result<Option<SpaceOut>, ErrorObjectOwned>;
+
     #[method(name = "estimatebid")]
     async fn estimate_bid(&self, target: usize) -> Result<u64, ErrorObjectOwned>;
 
     #[method(name = "getrollout")]
     async fn get_rollout(&self, target: usize) -> Result<Vec<(u32, SpaceHash)>, ErrorObjectOwned>;
-
-    #[method(name = "getspaceout")]
-    async fn get_spaceout(&self, outpoint: OutPoint) -> Result<Option<SpaceOut>, ErrorObjectOwned>;
 
     #[method(name = "getblockdata")]
     async fn get_block_data(
@@ -628,24 +628,6 @@ impl RpcServer for RpcServerImpl {
         Ok(info)
     }
 
-    async fn estimate_bid(&self, target: usize) -> Result<u64, ErrorObjectOwned> {
-        let info = self
-            .store
-            .estimate_bid(target)
-            .await
-            .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))?;
-        Ok(info)
-    }
-
-    async fn get_rollout(&self, target: usize) -> Result<Vec<(u32, SpaceHash)>, ErrorObjectOwned> {
-        let rollouts = self
-            .store
-            .get_rollout(target)
-            .await
-            .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))?;
-        Ok(rollouts)
-    }
-
     async fn get_space_owner(&self, space: String) -> Result<Option<OutPoint>, ErrorObjectOwned> {
         let space = SName::from_str(&space).map_err(|_| {
             ErrorObjectOwned::owned(
@@ -672,6 +654,24 @@ impl RpcServer for RpcServerImpl {
             .await
             .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))?;
         Ok(spaceout)
+    }
+
+    async fn estimate_bid(&self, target: usize) -> Result<u64, ErrorObjectOwned> {
+        let info = self
+            .store
+            .estimate_bid(target)
+            .await
+            .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))?;
+        Ok(info)
+    }
+
+    async fn get_rollout(&self, target: usize) -> Result<Vec<(u32, SpaceHash)>, ErrorObjectOwned> {
+        let rollouts = self
+            .store
+            .get_rollout(target)
+            .await
+            .map_err(|error| ErrorObjectOwned::owned(-1, error.to_string(), None::<String>))?;
+        Ok(rollouts)
     }
 
     async fn get_block_data(

--- a/protocol/src/hasher.rs
+++ b/protocol/src/hasher.rs
@@ -1,9 +1,10 @@
-use crate::alloc::string::ToString;
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};
 use bitcoin::{Amount, OutPoint};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use crate::alloc::string::ToString;
 
 pub type Hash = [u8; 32];
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -5,8 +5,7 @@ extern crate core;
 
 pub extern crate bitcoin;
 
-use alloc::vec;
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};

--- a/protocol/src/script.rs
+++ b/protocol/src/script.rs
@@ -1,5 +1,4 @@
-use alloc::collections::btree_map::BTreeMap;
-use alloc::vec::Vec;
+use alloc::{collections::btree_map::BTreeMap, vec::Vec};
 
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};

--- a/protocol/src/validate.rs
+++ b/protocol/src/validate.rs
@@ -1,6 +1,4 @@
-use alloc::collections::btree_map::BTreeMap;
-use alloc::vec;
-use alloc::vec::Vec;
+use alloc::{collections::btree_map::BTreeMap, vec, vec::Vec};
 
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};


### PR DESCRIPTION
Make RPC  more friendly by accepting space names instead of hashes. There's no tooling yet to get the actual space hash so we will revisit this once we design a proper public API