### PR TITLE
Investigate named wallet export issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Run tests
-        run: cargo test
+        run: cargo test -- --test-threads=1

--- a/node/tests/space_cli_tests.rs
+++ b/node/tests/space_cli_tests.rs
@@ -14,18 +14,15 @@ mod tests {
     fn setup(args: &[&str]) -> Result<(SpaceD, Command)> {
         env_logger::init();
         let spaced = SpaceD::new()?;
-
         let mut space_cli = Command::cargo_bin("space-cli")?;
         space_cli
             .arg("--chain")
             .arg("regtest")
             .arg("--spaced-rpc-url")
             .arg(spaced.spaced_rpc_url());
-
         for arg in args {
             space_cli.arg(arg);
         }
-
         Ok((spaced, space_cli))
     }
 

--- a/node/tests/space_cli_tests.rs
+++ b/node/tests/space_cli_tests.rs
@@ -10,6 +10,7 @@ mod tests {
     use spaced::config::ExtendedNetwork;
     use spaced::rpc::ServerInfo;
     use std::process::Command;
+    use wallet::WalletExport;
 
     fn setup(spaced_rpc_url: String, args: &[&str]) -> Result<Command> {
         let mut space_cli = Command::cargo_bin("space-cli")?;
@@ -67,4 +68,69 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn create_named_wallet_works() -> Result<()> {
+        let spaced = SpaceD::new()?;
+        let mut create_named_wallet = setup(spaced.spaced_rpc_url(), &["createwallet", "custom"])?;
+
+        create_named_wallet
+            .assert()
+            .success()
+            .stdout(predicate::str::is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn create_duplicate_named_wallet_fails() -> Result<()> {
+        let spaced = SpaceD::new()?;
+        let name = "custom";
+        let _ = setup(spaced.spaced_rpc_url(), &["createwallet", name])?.status()?;
+        let mut create_wallet_again = setup(spaced.spaced_rpc_url(), &["createwallet", name])?;
+
+        create_wallet_again
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(format!(
+                "Wallet `{}` already exists",
+                name
+            )));
+
+        Ok(())
+    }
+
+    #[test]
+    fn wallet_export_works() -> Result<()> {
+        let spaced = SpaceD::new()?;
+        let _ = setup(spaced.spaced_rpc_url(), &["createwallet"])?.status()?;
+        let mut export_wallet = setup(spaced.spaced_rpc_url(), &["exportwallet"])?;
+
+        export_wallet
+            .assert()
+            .success()
+            .stdout(predicate::function(|x: &str| {
+                let export: WalletExport = from_str(x).unwrap();
+                return export.label == "default";
+            }));
+
+        Ok(())
+    }
+
+    #[test]
+    fn named_wallet_export_works() -> Result<()> {
+        let spaced = SpaceD::new()?;
+        let name = "custom";
+        let _ = setup(spaced.spaced_rpc_url(), &["createwallet", name])?.status()?;
+        let mut export_wallet = setup(spaced.spaced_rpc_url(), &["exportwallet", name])?;
+
+        export_wallet
+            .assert()
+            .success()
+            .stdout(predicate::function(|x: &str| {
+                let export: WalletExport = from_str(x).unwrap();
+                return export.label == name;
+            }));
+
+        Ok(())
+    }
 }

--- a/node/tests/space_cli_tests.rs
+++ b/node/tests/space_cli_tests.rs
@@ -11,26 +11,26 @@ mod tests {
     use spaced::rpc::ServerInfo;
     use std::process::Command;
 
-    fn setup(args: &[&str]) -> Result<(SpaceD, Command)> {
-        env_logger::init();
-        let spaced = SpaceD::new()?;
+    fn setup(spaced_rpc_url: String, args: &[&str]) -> Result<Command> {
         let mut space_cli = Command::cargo_bin("space-cli")?;
         space_cli
             .arg("--chain")
             .arg("regtest")
             .arg("--spaced-rpc-url")
-            .arg(spaced.spaced_rpc_url());
+            .arg(spaced_rpc_url);
         for arg in args {
             space_cli.arg(arg);
         }
-        Ok((spaced, space_cli))
+        Ok(space_cli)
     }
 
     #[test]
     fn test_get_server_info() -> Result<()> {
-        let (_spaced, mut space_cli) = setup(&["getserverinfo"])?;
+        env_logger::init();
+        let spaced = SpaceD::new()?;
+        let mut get_server_info = setup(spaced.spaced_rpc_url(), &["getserverinfo"])?;
 
-        space_cli
+        get_server_info
             .assert()
             .success()
             .stdout(predicate::function(|x: &str| {

--- a/node/tests/space_cli_tests.rs
+++ b/node/tests/space_cli_tests.rs
@@ -29,8 +29,8 @@ mod tests {
         Ok((spaced, space_cli))
     }
 
-    #[tokio::test]
-    async fn test_get_server_info() -> Result<()> {
+    #[test]
+    fn test_get_server_info() -> Result<()> {
         let (_spaced, mut space_cli) = setup(&["getserverinfo"])?;
 
         space_cli

--- a/node/tests/space_cli_tests.rs
+++ b/node/tests/space_cli_tests.rs
@@ -40,4 +40,24 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_default_wallet_cannot_be_duplicated() -> Result<()> {
+        env_logger::init();
+        let spaced = SpaceD::new()?;
+        let mut create_wallet = setup(spaced.spaced_rpc_url(), &["createwallet"])?;
+        create_wallet
+            .assert()
+            .success()
+            .stdout(predicate::str::is_empty());
+
+        let mut create_wallet_again = setup(spaced.spaced_rpc_url(), &["createwallet"])?;
+        create_wallet_again
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Wallet `default` already exists"));
+
+        Ok(())
+    }
+
 }

--- a/node/tests/space_cli_tests.rs
+++ b/node/tests/space_cli_tests.rs
@@ -25,8 +25,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_server_info() -> Result<()> {
-        env_logger::init();
+    fn get_server_info_works() -> Result<()> {
         let spaced = SpaceD::new()?;
         let mut get_server_info = setup(spaced.spaced_rpc_url(), &["getserverinfo"])?;
 
@@ -42,16 +41,24 @@ mod tests {
     }
 
     #[test]
-    fn test_default_wallet_cannot_be_duplicated() -> Result<()> {
-        env_logger::init();
+    fn create_wallet_works() -> Result<()> {
         let spaced = SpaceD::new()?;
         let mut create_wallet = setup(spaced.spaced_rpc_url(), &["createwallet"])?;
+
         create_wallet
             .assert()
             .success()
             .stdout(predicate::str::is_empty());
 
+        Ok(())
+    }
+
+    #[test]
+    fn create_duplicate_wallet_fails() -> Result<()> {
+        let spaced = SpaceD::new()?;
+        let _ = setup(spaced.spaced_rpc_url(), &["createwallet"])?.status()?;
         let mut create_wallet_again = setup(spaced.spaced_rpc_url(), &["createwallet"])?;
+
         create_wallet_again
             .assert()
             .success()


### PR DESCRIPTION
In this PR, we investigate #7 (with an integration test of course)

In addition, we:
* Add a framework to quickly create spaced-cli commands with a spaced instance for tests
* Add tests for creating default and named wallets, and failures on attempting to recreate an existing wallet
* Add tests for exporting default and named wallets (which covers the issue above)
* Use a single thread to run tests to avoid:
  - hogging several available ports to run the daemons
  - running out of available ports
