### PR TITLE
Structure update

### DIFF
--- a/node/src/bin/space-cli.rs
+++ b/node/src/bin/space-cli.rs
@@ -10,7 +10,7 @@ use jsonrpsee::{
 };
 use protocol::{
     bitcoin::{Amount, FeeRate, OutPoint, Txid},
-    hasher::{KeyHasher, SpaceHash},
+    hasher::{KeyHasher, SpaceKey},
     opcodes::OP_SETALL,
     sname::{NameLike, SName},
     Covenant, FullSpaceOut,
@@ -372,7 +372,7 @@ async fn main() -> anyhow::Result<()> {
 fn space_hash(spaceish: &str) -> anyhow::Result<String> {
     let space = normalize_space(&spaceish);
     let sname = SName::from_str(&space)?;
-    let spacehash = SpaceHash::from(Sha256::hash(sname.to_bytes()));
+    let spacehash = SpaceKey::from(Sha256::hash(sname.to_bytes()));
     Ok(hex::encode(spacehash.as_slice()))
 }
 
@@ -394,7 +394,13 @@ async fn handle_commands(
 
                 if let Some(outpoint) = outpoint {
                     if let Some(spaceout) = cli.client.get_spaceout(outpoint).await? {
-                        spaceouts.push((priority, FullSpaceOut { outpoint, spaceout }));
+                        spaceouts.push((
+                            priority,
+                            FullSpaceOut {
+                                txid: outpoint.txid,
+                                spaceout,
+                            },
+                        ));
                     }
                 }
             }

--- a/node/src/bin/spaced.rs
+++ b/node/src/bin/spaced.rs
@@ -6,7 +6,7 @@ use log::error;
 use spaced::{
     config::{safe_exit, Args},
     rpc::{AsyncChainState, LoadedWallet, RpcServerImpl, WalletManager},
-    source::BitcoinBlockSource,
+    source::{BitcoinBlockSource, BitcoinRpc},
     store,
     sync::Spaced,
     wallets::RpcWallet,
@@ -16,7 +16,6 @@ use tokio::{
     sync::{broadcast, mpsc},
     task::{JoinHandle, JoinSet},
 };
-use spaced::source::BitcoinRpc;
 
 #[tokio::main]
 async fn main() {

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -173,7 +173,9 @@ impl Args {
         let block_index = if args.block_index {
             let block_db_path = data_dir.join("block_index.sdb");
             if !initial_sync && !block_db_path.exists() {
-                return Err(anyhow::anyhow!("Block index must be enabled from the initial sync."))
+                return Err(anyhow::anyhow!(
+                    "Block index must be enabled from the initial sync."
+                ));
             }
             let block_store = Store::open(block_db_path)?;
             let index = LiveStore {
@@ -184,7 +186,9 @@ impl Args {
                 let tip_1 = index.state.tip.read().expect("index");
                 let tip_2 = chain.state.tip.read().expect("tip");
                 if tip_1.height != tip_2.height || tip_1.hash != tip_2.hash {
-                    return Err(anyhow::anyhow!("Protocol and block index states don't match."))
+                    return Err(anyhow::anyhow!(
+                        "Protocol and block index states don't match."
+                    ));
                 }
             }
             Some(index)

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -159,23 +159,37 @@ impl Args {
             bitcoin_rpc_auth,
         );
 
-        std::fs::create_dir_all(data_dir.clone())?;
+        fs::create_dir_all(data_dir.clone())?;
 
-        let chain_store = Store::open(data_dir.join("protocol.sdb"))?;
+        let proto_db_path = data_dir.join("protocol.sdb");
+        let initial_sync = !proto_db_path.exists();
+
+        let chain_store = Store::open(proto_db_path)?;
         let chain = LiveStore {
             state: chain_store.begin(&genesis)?,
             store: chain_store,
         };
 
-        let block_index = match args.block_index {
-            true => {
-                let block_store = Store::open(data_dir.join("blocks.sdb"))?;
-                Some(LiveStore {
-                    state: block_store.begin(&genesis).expect("begin block index"),
-                    store: block_store,
-                })
+        let block_index = if args.block_index {
+            let block_db_path = data_dir.join("block_index.sdb");
+            if !initial_sync && !block_db_path.exists() {
+                return Err(anyhow::anyhow!("Block index must be enabled from the initial sync."))
             }
-            false => None,
+            let block_store = Store::open(block_db_path)?;
+            let index = LiveStore {
+                state: block_store.begin(&genesis).expect("begin block index"),
+                store: block_store,
+            };
+            {
+                let tip_1 = index.state.tip.read().expect("index");
+                let tip_2 = chain.state.tip.read().expect("tip");
+                if tip_1.height != tip_2.height || tip_1.hash != tip_2.hash {
+                    return Err(anyhow::anyhow!("Protocol and block index states don't match."))
+                }
+            }
+            Some(index)
+        } else {
+            None
         };
 
         Ok(Spaced {

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -39,7 +39,7 @@ pub struct Node {
 /// relevant to the Spaces protocol
 #[derive(Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct BlockMeta {
-    tx_meta: Vec<TxChangeSet>,
+    pub tx_meta: Vec<TxChangeSet>,
 }
 
 #[derive(Debug)]

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -8,13 +8,14 @@ use bincode::{Decode, Encode};
 use protocol::{
     bitcoin::{Amount, Block, BlockHash, OutPoint},
     constants::{ChainAnchor, ROLLOUT_BATCH_SIZE, ROLLOUT_BLOCK_INTERVAL},
-    hasher::{BidHash, KeyHasher, OutpointHash, SpaceHash},
-    prepare::PreparedTransaction,
+    hasher::{BidKey, KeyHasher, OutpointKey, SpaceKey},
+    prepare::TxContext,
     sname::NameLike,
-    validate::{ErrorOut, MetaOutKind, TxInKind, TxOutKind, ValidatedTransaction, Validator},
+    validate::{UpdateKind, TxChangeSet, Validator},
     Covenant, FullSpaceOut, RevokeReason, SpaceOut,
 };
 use serde::{Deserialize, Serialize};
+use wallet::bitcoin::Transaction;
 
 use crate::{
     source::BitcoinRpcError,
@@ -34,11 +35,11 @@ pub struct Node {
     validator: Validator,
 }
 
-/// A block structure containing validated transactions
+/// A block structure containing validated transaction metadata
 /// relevant to the Spaces protocol
 #[derive(Clone, Serialize, Deserialize, Encode, Decode)]
-pub struct ValidatedBlock {
-    tx_data: Vec<ValidatedTransaction>,
+pub struct BlockMeta {
+    tx_meta: Vec<TxChangeSet>,
 }
 
 #[derive(Debug)]
@@ -73,7 +74,7 @@ impl Node {
         block_hash: BlockHash,
         block: Block,
         get_block_data: bool,
-    ) -> Result<Option<ValidatedBlock>> {
+    ) -> Result<Option<BlockMeta>> {
         {
             let tip = chain.state.tip.read().expect("read tip");
             if tip.hash != block.header.prev_blockhash || tip.height + 1 != height {
@@ -85,7 +86,7 @@ impl Node {
             }
         }
 
-        let mut block_data = ValidatedBlock { tx_data: vec![] };
+        let mut block_data = BlockMeta { tx_meta: vec![] };
 
         if (height - 1) % ROLLOUT_BLOCK_INTERVAL == 0 {
             let batch = Self::get_rollout_batch(ROLLOUT_BATCH_SIZE, chain)?;
@@ -94,137 +95,115 @@ impl Node {
                 .expect("expected a coinbase tx to be present in the block")
                 .clone();
 
-            let validated = self.validator.rollout(height, coinbase, batch);
+            let validated = self.validator.rollout(height, &coinbase, batch);
             if get_block_data {
-                block_data.tx_data.push(validated.clone());
+                block_data.tx_meta.push(validated.clone());
             }
 
-            self.apply_tx(&mut chain.state, validated);
+            self.apply_tx(&mut chain.state, &coinbase, validated);
         }
 
         for tx in block.txdata {
             let prepared_tx =
-                { PreparedTransaction::from_tx::<LiveSnapshot, Sha256>(&mut chain.state, tx)? };
+                { TxContext::from_tx::<LiveSnapshot, Sha256>(&mut chain.state, &tx)? };
 
             if let Some(prepared_tx) = prepared_tx {
-                let validated_tx = self.validator.process(height, prepared_tx);
+                let validated_tx = self.validator.process(height, &tx, prepared_tx);
+
                 if get_block_data {
-                    block_data.tx_data.push(validated_tx.clone());
+                    block_data.tx_meta.push(validated_tx.clone());
                 }
-                self.apply_tx(&mut chain.state, validated_tx);
+                self.apply_tx(&mut chain.state, &tx, validated_tx);
             }
         }
         let mut tip = chain.state.tip.write().expect("write tip");
         tip.height = height;
         tip.hash = block_hash;
 
-        if get_block_data && !block_data.tx_data.is_empty() {
+        if get_block_data && !block_data.tx_meta.is_empty() {
             return Ok(Some(block_data));
         }
         Ok(None)
     }
 
-    fn apply_tx(&self, state: &mut LiveSnapshot, changeset: ValidatedTransaction) {
+    fn apply_tx(&self, state: &mut LiveSnapshot, tx: &Transaction, changeset: TxChangeSet) {
         // Remove spends
-        for input in changeset.input {
-            match input {
-                TxInKind::CoinIn(_) => {
-                    // not relevant to spaces
-                }
-                TxInKind::SpaceIn(spacein) => {
-                    // remove spend
-                    let spend = OutpointHash::from_outpoint::<Sha256>(spacein.txin.previous_output);
-                    state.remove(spend);
-                }
-            }
+        for spend in changeset.spends.into_iter() {
+            let previous = tx.input[spend.n].previous_output;
+            let spend = OutpointKey::from_outpoint::<Sha256>(previous);
+            state.remove(spend);
         }
 
         // Apply outputs
-        for (index, output) in changeset.output.into_iter().enumerate() {
-            match output {
-                TxOutKind::CoinOut(_) => {
-                    // not relevant to spaces
-                }
-                TxOutKind::SpaceOut(spaceout) => {
-                    if let Some(space) = spaceout.space.as_ref() {
-                        assert!(
-                            !matches!(space.covenant, Covenant::Bid { .. }),
-                            "bid unexpected"
-                        );
-                    }
-                    let outpoint = OutPoint {
-                        txid: changeset.txid,
-                        vout: index as u32,
-                    };
-
-                    // Space => Outpoint
-                    if let Some(space) = spaceout.space.as_ref() {
-                        let space_key = SpaceHash::from(Sha256::hash(space.name.to_bytes()));
-                        state.insert_space(space_key, outpoint.into());
-                    }
-                    // Outpoint => SpaceOut
-                    let outpoint_key = OutpointHash::from_outpoint::<Sha256>(outpoint);
-                    state.insert_spaceout(outpoint_key, spaceout);
-                }
+        for create in changeset.creates.into_iter() {
+            if let Some(space) = create.space.as_ref() {
+                assert!(
+                    !matches!(space.covenant, Covenant::Bid { .. }),
+                    "bid unexpected"
+                );
             }
+            let outpoint = OutPoint {
+                txid: changeset.txid,
+                vout: create.n as u32,
+            };
+
+            // Space => Outpoint
+            if let Some(space) = create.space.as_ref() {
+                let space_key = SpaceKey::from(Sha256::hash(space.name.to_bytes()));
+                state.insert_space(space_key, outpoint.into());
+            }
+            // Outpoint => SpaceOut
+            let outpoint_key = OutpointKey::from_outpoint::<Sha256>(outpoint);
+            state.insert_spaceout(outpoint_key, create);
         }
 
         // Apply meta outputs
-        for meta_output in changeset.meta_output {
-            match meta_output {
-                MetaOutKind::ErrorOut(errrout) => {
-                    match errrout {
-                        ErrorOut::Reject(_) => {
-                            // no state changes as it doesn't
-                            // modify any existing spaces
-                        }
-                        ErrorOut::Revoke(params) => {
-                            match params.reason {
-                                RevokeReason::BidPsbt(_)
-                                | RevokeReason::PrematureClaim
-                                | RevokeReason::BadSpend => {
-                                    // Since these are caused by spends
-                                    // Outpoint -> Spaceout mapping is already removed,
-                                    let space = params.spaceout.spaceout.space.unwrap();
-                                    let base_hash = Sha256::hash(space.name.to_bytes());
+        for update in changeset.updates {
+            match update.kind {
+                UpdateKind::Revoke(params) => {
+                    match params {
+                        RevokeReason::BidPsbt(_)
+                        | RevokeReason::PrematureClaim
+                        | RevokeReason::BadSpend => {
+                            // Since these are caused by spends
+                            // Outpoint -> Spaceout mapping is already removed,
+                            let space = update.output.spaceout.space.unwrap();
+                            let base_hash = Sha256::hash(space.name.to_bytes());
 
-                                    // Remove Space -> Outpoint
-                                    let space_key = SpaceHash::from(base_hash);
-                                    state.remove(space_key);
+                            // Remove Space -> Outpoint
+                            let space_key = SpaceKey::from(base_hash);
+                            state.remove(space_key);
 
-                                    // Remove any bids from pre-auction pool
-                                    match space.covenant {
-                                        Covenant::Bid {
-                                            total_burned,
-                                            claim_height,
-                                            ..
-                                        } => {
-                                            if claim_height.is_none() {
-                                                let bid_key =
-                                                    BidHash::from_bid(total_burned, base_hash);
-                                                state.remove(bid_key);
-                                            }
-                                        }
-                                        _ => {}
+                            // Remove any bids from pre-auction pool
+                            match space.covenant {
+                                Covenant::Bid {
+                                    total_burned,
+                                    claim_height,
+                                    ..
+                                } => {
+                                    if claim_height.is_none() {
+                                        let bid_key = BidKey::from_bid(total_burned, base_hash);
+                                        state.remove(bid_key);
                                     }
                                 }
-                                RevokeReason::Expired => {
-                                    // Space => Outpoint mapping will be removed
-                                    // since this type of revocation only happens when an
-                                    // expired space is being re-opened for auction.
-                                    // No bids here so only remove Outpoint -> Spaceout
-                                    let hash = OutpointHash::from_outpoint::<Sha256>(
-                                        params.spaceout.outpoint,
-                                    );
-                                    state.remove(hash);
-                                }
+                                _ => {}
                             }
+                        }
+                        RevokeReason::Expired => {
+                            // Space => Outpoint mapping will be removed
+                            // since this type of revocation only happens when an
+                            // expired space is being re-opened for auction.
+                            // No bids here so only remove Outpoint -> Spaceout
+                            let hash =
+                                OutpointKey::from_outpoint::<Sha256>(update.output.outpoint());
+                            state.remove(hash);
                         }
                     }
                 }
-                MetaOutKind::RolloutOut(rollout) => {
+                UpdateKind::Rollout(rollout) => {
                     let base_hash = Sha256::hash(
-                        rollout
+                        update
+                            .output
                             .spaceout
                             .space
                             .as_ref()
@@ -232,17 +211,19 @@ impl Node {
                             .name
                             .to_bytes(),
                     );
-                    let bid_key = BidHash::from_bid(rollout.bid_value, base_hash);
+                    let bid_key = BidKey::from_bid(rollout.priority, base_hash);
 
-                    let outpoint_key = OutpointHash::from_outpoint::<Sha256>(rollout.outpoint);
+                    let outpoint_key =
+                        OutpointKey::from_outpoint::<Sha256>(update.output.outpoint());
 
                     state.remove(bid_key);
-                    state.insert_spaceout(outpoint_key, rollout.spaceout);
+                    state.insert_spaceout(outpoint_key, update.output.spaceout);
                 }
-                MetaOutKind::SpaceOut(carried) => {
+                UpdateKind::Bid => {
                     // Only bids are expected in meta outputs
                     let base_hash = Sha256::hash(
-                        carried
+                        update
+                            .output
                             .spaceout
                             .space
                             .as_ref()
@@ -251,25 +232,27 @@ impl Node {
                             .to_bytes(),
                     );
 
-                    let (bid_value, previous_bid) = unwrap_bid_value(&carried.spaceout);
+                    let (bid_value, previous_bid) =
+                        unwrap_bid_value(&update.output.spaceout);
 
-                    let bid_hash = BidHash::from_bid(bid_value, base_hash);
-                    let space_key = SpaceHash::from(base_hash);
+                    let bid_hash = BidKey::from_bid(bid_value, base_hash);
+                    let space_key = SpaceKey::from(base_hash);
 
-                    match carried.spaceout.space.as_ref().expect("space").covenant {
+                    match update.output.spaceout.space.as_ref().expect("space").covenant {
                         Covenant::Bid { claim_height, .. } => {
                             if claim_height.is_none() {
-                                let prev_bid_hash = BidHash::from_bid(previous_bid, base_hash);
+                                let prev_bid_hash = BidKey::from_bid(previous_bid, base_hash);
                                 state.update_bid(Some(prev_bid_hash), bid_hash, space_key);
                             }
                         }
                         _ => panic!("expected bid"),
                     }
 
-                    state.insert_space(space_key, carried.outpoint.into());
+                    let carried_outpoint = update.output.outpoint();
+                    state.insert_space(space_key, carried_outpoint.into());
 
-                    let outpoint_key = OutpointHash::from_outpoint::<Sha256>(carried.outpoint);
-                    state.insert_spaceout(outpoint_key, carried.spaceout);
+                    let outpoint_key = OutpointKey::from_outpoint::<Sha256>(carried_outpoint);
+                    state.insert_spaceout(outpoint_key, update.output.spaceout);
                 }
             }
         }
@@ -291,7 +274,7 @@ impl Node {
             let mut hash = [0u8; 32];
             hash.copy_from_slice(raw_hash.as_slice());
 
-            let space_hash = SpaceHash::from_raw(hash)?;
+            let space_hash = SpaceKey::from_raw(hash)?;
             let full = chain.state.get_space_info(&space_hash)?;
 
             if let Some(full) = full {

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -11,7 +11,7 @@ use protocol::{
     hasher::{BidKey, KeyHasher, OutpointKey, SpaceKey},
     prepare::TxContext,
     sname::NameLike,
-    validate::{UpdateKind, TxChangeSet, Validator},
+    validate::{TxChangeSet, UpdateKind, Validator},
     Covenant, FullSpaceOut, RevokeReason, SpaceOut,
 };
 use serde::{Deserialize, Serialize};
@@ -232,13 +232,19 @@ impl Node {
                             .to_bytes(),
                     );
 
-                    let (bid_value, previous_bid) =
-                        unwrap_bid_value(&update.output.spaceout);
+                    let (bid_value, previous_bid) = unwrap_bid_value(&update.output.spaceout);
 
                     let bid_hash = BidKey::from_bid(bid_value, base_hash);
                     let space_key = SpaceKey::from(base_hash);
 
-                    match update.output.spaceout.space.as_ref().expect("space").covenant {
+                    match update
+                        .output
+                        .spaceout
+                        .space
+                        .as_ref()
+                        .expect("space")
+                        .covenant
+                    {
                         Covenant::Bid { claim_height, .. } => {
                             if claim_height.is_none() {
                                 let prev_bid_hash = BidKey::from_bid(previous_bid, base_hash);

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -875,7 +875,7 @@ impl AsyncChainState {
                 height
             ));
         }
-        Err(anyhow!("Could not retrieve block"))
+        Ok(None)
     }
 
     pub async fn handle_command(

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -828,7 +828,7 @@ impl AsyncChainState {
         let block_hash = BlockHash::from_str(
             info.get("blockhash")
                 .and_then(|t| t.as_str())
-                .ok_or_else(|| anyhow!("Could not retrieve block hash"))?,
+                .ok_or_else(|| anyhow!("Could not retrieve block hash for tx (is it in the mempool?)"))?,
         )?;
         let block = Self::get_indexed_block(index, &block_hash, client, rpc, chain_state).await?;
 

--- a/node/src/source.rs
+++ b/node/src/source.rs
@@ -141,7 +141,7 @@ impl BitcoinRpc {
         self.make_request("getblockcount", params)
     }
 
-    pub fn get_block_header(&self, hash : &BlockHash) -> BitcoinRpcRequest {
+    pub fn get_block_header(&self, hash: &BlockHash) -> BitcoinRpcRequest {
         let params = serde_json::json!([hash]);
         self.make_request("getblockheader", params)
     }

--- a/node/src/source.rs
+++ b/node/src/source.rs
@@ -146,6 +146,11 @@ impl BitcoinRpc {
         self.make_request("getblockheader", params)
     }
 
+    pub fn get_raw_transaction(&self, hash: &Txid, verbose: bool) -> BitcoinRpcRequest {
+        let params = serde_json::json!([hash, verbose]);
+        self.make_request("getrawtransaction", params)
+    }
+
     pub fn get_block_hash(&self, height: u32) -> BitcoinRpcRequest {
         let params = serde_json::json!([height]);
 

--- a/node/src/source.rs
+++ b/node/src/source.rs
@@ -141,6 +141,11 @@ impl BitcoinRpc {
         self.make_request("getblockcount", params)
     }
 
+    pub fn get_block_header(&self, hash : &BlockHash) -> BitcoinRpcRequest {
+        let params = serde_json::json!([hash]);
+        self.make_request("getblockheader", params)
+    }
+
     pub fn get_block_hash(&self, height: u32) -> BitcoinRpcRequest {
         let params = serde_json::json!([height]);
 

--- a/node/src/sync.rs
+++ b/node/src/sync.rs
@@ -11,7 +11,7 @@ use tokio::sync::broadcast;
 
 use crate::{
     config::ExtendedNetwork,
-    node::{BlockSource, Node, ValidatedBlock},
+    node::{BlockMeta, BlockSource, Node},
     source::{BitcoinBlockSource, BitcoinRpc, BlockEvent, BlockFetchError, BlockFetcher},
     store::LiveStore,
 };
@@ -98,7 +98,7 @@ impl Spaced {
     pub fn save_block(
         store: LiveStore,
         block_hash: BlockHash,
-        block: ValidatedBlock,
+        block: BlockMeta,
     ) -> anyhow::Result<()> {
         store
             .state

--- a/protocol/src/constants.rs
+++ b/protocol/src/constants.rs
@@ -1,5 +1,6 @@
 use bitcoin::{
     absolute::{Height, LockTime},
+    blockdata::transaction::Version,
     hashes::Hash,
     BlockHash, Sequence,
 };
@@ -35,7 +36,7 @@ pub const RENEWAL_INTERVAL: u32 = 144 * 365;
 
 /// The transaction version used in the carried bid PSBT.
 /// This must match for correct PSBT reconstruction.
-pub const BID_PSBT_TX_VERSION: i32 = 2;
+pub const BID_PSBT_TX_VERSION: Version = Version::TWO;
 
 /// The lock time for bid PSBTs.
 /// This must match for correct PSBT reconstruction.

--- a/protocol/src/hasher.rs
+++ b/protocol/src/hasher.rs
@@ -15,12 +15,12 @@ pub trait KeyHasher {
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-pub struct SpaceHash(Hash);
+pub struct SpaceKey(Hash);
 
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-pub struct BidHash(Hash);
+pub struct BidKey(Hash);
 
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -38,23 +38,23 @@ impl BaseHash {
 #[derive(Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-pub struct OutpointHash(Hash);
+pub struct OutpointKey(Hash);
 
 pub trait KeyHash {}
-impl KeyHash for SpaceHash {}
-impl KeyHash for OutpointHash {}
-impl KeyHash for BidHash {}
+impl KeyHash for SpaceKey {}
+impl KeyHash for OutpointKey {}
+impl KeyHash for BidKey {}
 impl KeyHash for BaseHash {}
 
-impl From<Hash> for SpaceHash {
+impl From<Hash> for SpaceKey {
     fn from(mut value: Hash) -> Self {
         value[0] &= 0b0111_1111;
         value[31] &= 0b1111_1110;
-        SpaceHash(value)
+        SpaceKey(value)
     }
 }
 
-impl SpaceHash {
+impl SpaceKey {
     #[inline(always)]
     pub fn from_raw(value: Hash) -> crate::errors::Result<Self> {
         if (value[0] & 0b1000_0000) == 0 && (value[31] & 0b0000_0001) == 0 {
@@ -75,20 +75,20 @@ impl SpaceHash {
     }
 }
 
-impl From<SpaceHash> for Hash {
-    fn from(value: SpaceHash) -> Self {
+impl From<SpaceKey> for Hash {
+    fn from(value: SpaceKey) -> Self {
         value.0
     }
 }
 
-impl From<BidHash> for Hash {
-    fn from(value: BidHash) -> Self {
+impl From<BidKey> for Hash {
+    fn from(value: BidKey) -> Self {
         value.0
     }
 }
 
-impl From<OutpointHash> for Hash {
-    fn from(value: OutpointHash) -> Self {
+impl From<OutpointKey> for Hash {
+    fn from(value: OutpointKey) -> Self {
         value.0
     }
 }
@@ -105,7 +105,7 @@ impl From<BaseHash> for Hash {
     }
 }
 
-impl OutpointHash {
+impl OutpointKey {
     pub fn from_outpoint<H: KeyHasher>(value: OutPoint) -> Self {
         let mut buffer = [0u8; 32 + 4];
         buffer[0..32].copy_from_slice(value.txid.as_ref());
@@ -115,7 +115,7 @@ impl OutpointHash {
     }
 }
 
-impl BidHash {
+impl BidKey {
     pub fn from_bid(bid_value: Amount, mut base_hash: Hash) -> Self {
         let priority = core::cmp::min(bid_value.to_sat(), (1 << 31) - 1) as u32;
         let priority_bytes = priority.to_be_bytes();
@@ -123,7 +123,7 @@ impl BidHash {
 
         // first bit is always 1
         base_hash[0] |= 0b1000_0000;
-        BidHash(base_hash)
+        BidKey(base_hash)
     }
 
     pub fn priority(&self) -> u32 {
@@ -152,20 +152,20 @@ impl BidHash {
     }
 }
 
-impl From<Hash> for BidHash {
+impl From<Hash> for BidKey {
     fn from(mut value: Hash) -> Self {
         // First bit is always 0 and last bit is always 1
         value[0] &= 0b0111_1111;
         value[31] |= 0b0000_0001;
-        BidHash(value)
+        BidKey(value)
     }
 }
 
-impl From<Hash> for OutpointHash {
+impl From<Hash> for OutpointKey {
     fn from(mut value: Hash) -> Self {
         // First bit is always 0 and last bit is always 1
         value[0] &= 0b0111_1111;
         value[31] |= 0b0000_0001;
-        OutpointHash(value)
+        OutpointKey(value)
     }
 }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -115,7 +115,10 @@ pub enum Covenant {
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-#[cfg_attr(feature = "serde", serde(rename_all = "snake_case", tag = "revoke_reason"))]
+#[cfg_attr(
+    feature = "serde",
+    serde(rename_all = "snake_case", tag = "revoke_reason")
+)]
 pub enum RevokeReason {
     BidPsbt(BidPsbtReason),
     /// Space was prematurely spent during the auctions phase
@@ -142,7 +145,7 @@ pub enum RejectReason {
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
-    serde(rename_all = "snake_case", tag = "bid_psbt_reason"),
+    serde(rename_all = "snake_case", tag = "bid_psbt_reason")
 )]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub enum BidPsbtReason {

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -15,7 +15,7 @@ use bitcoin::{
     sighash::{Prevouts, SighashCache, TapSighashType},
     taproot,
     transaction::Version,
-    Amount, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Witness,
+    Amount, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid, Witness,
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -39,7 +39,7 @@ pub mod validate;
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub struct FullSpaceOut {
     #[cfg_attr(feature = "bincode", bincode(with_serde))]
-    pub outpoint: OutPoint,
+    pub txid: Txid,
 
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub spaceout: SpaceOut,
@@ -51,15 +51,16 @@ pub struct FullSpaceOut {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub struct SpaceOut {
+    pub n: usize,
+    /// Any space associated with this output
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub space: Option<Space>,
     /// The value of the output, in satoshis.
     #[cfg_attr(feature = "bincode", bincode(with_serde))]
     pub value: Amount,
     /// The script which must be satisfied for the output to be spent.
     #[cfg_attr(feature = "bincode", bincode(with_serde))]
     pub script_pubkey: ScriptBuf,
-    /// Any space associated with this output
-    #[cfg_attr(feature = "serde", serde(flatten))]
-    pub space: Option<Space>,
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -114,7 +115,7 @@ pub enum Covenant {
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case", tag = "revoke_reason"))]
 pub enum RevokeReason {
     BidPsbt(BidPsbtReason),
     /// Space was prematurely spent during the auctions phase
@@ -125,16 +126,24 @@ pub enum RevokeReason {
     Expired,
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, PartialEq, Debug, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(rename_all = "snake_case")
+)]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub enum RejectReason {
     AlreadyExists,
     BidPSBT(BidPsbtReason),
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(rename_all = "snake_case", tag = "bid_psbt_reason"),
+)]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub enum BidPsbtReason {
     Required,
@@ -162,7 +171,7 @@ impl Space {
         }
     }
 
-    pub fn is_bid_spend(&self, tx_version: i32, txin: &TxIn) -> bool {
+    pub fn is_bid_spend(&self, tx_version: Version, txin: &TxIn) -> bool {
         if tx_version != BID_PSBT_TX_VERSION
             || txin.sequence != BID_PSBT_INPUT_SEQUENCE
             || txin.witness.len() != 1
@@ -200,6 +209,13 @@ impl Space {
 }
 
 impl FullSpaceOut {
+    pub fn outpoint(&self) -> OutPoint {
+        OutPoint {
+            txid: self.txid,
+            vout: self.spaceout.n as u32,
+        }
+    }
+
     pub fn verify_bid_sig(&self) -> bool {
         if !self.spaceout.script_pubkey.is_p2tr() {
             return false;
@@ -329,10 +345,13 @@ impl FullSpaceOut {
         );
 
         let tx = Transaction {
-            version: Version(BID_PSBT_TX_VERSION),
+            version: BID_PSBT_TX_VERSION,
             lock_time: BID_PSBT_TX_LOCK_TIME,
             input: vec![TxIn {
-                previous_output: auctioned_utxo.outpoint,
+                previous_output: OutPoint {
+                    txid: auctioned_utxo.txid,
+                    vout: auctioned_utxo.spaceout.n as u32,
+                },
                 sequence: BID_PSBT_INPUT_SEQUENCE,
                 witness,
                 ..Default::default()

--- a/protocol/src/prepare.rs
+++ b/protocol/src/prepare.rs
@@ -47,10 +47,7 @@ pub struct AuctionedOutput {
 }
 
 pub trait DataSource {
-    fn get_space_outpoint(
-        &mut self,
-        space_hash: &SpaceKey,
-    ) -> Result<Option<OutPoint>>;
+    fn get_space_outpoint(&mut self, space_hash: &SpaceKey) -> Result<Option<OutPoint>>;
 
     fn get_spaceout(&mut self, outpoint: &OutPoint) -> Result<Option<SpaceOut>>;
 }

--- a/protocol/src/validate.rs
+++ b/protocol/src/validate.rs
@@ -1,16 +1,13 @@
 use alloc::{collections::btree_map::BTreeMap, vec, vec::Vec};
-
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};
-use bitcoin::{absolute, transaction::Version, Amount, OutPoint, Transaction, TxIn, TxOut, Txid};
+use bitcoin::{Amount, OutPoint, Transaction, Txid};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
     constants::{AUCTION_DURATION, AUCTION_EXTENSION_ON_BID, RENEWAL_INTERVAL, ROLLOUT_BATCH_SIZE},
-    prepare::{
-        is_magic_lock_time, AuctionedOutput, FullTxIn, PreparedTransaction, TrackableOutput, SSTXO,
-    },
+    prepare::{is_magic_lock_time, AuctionedOutput, TxContext, TrackableOutput, SSTXO},
     script::{OpOpenContext, ScriptError, SpaceKind},
     sname::SName,
     BidPsbtReason, Covenant, FullSpaceOut, RejectReason, RevokeReason, Space, SpaceOut,
@@ -22,92 +19,53 @@ pub struct Validator {}
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-/// A `ValidatedTransaction` is a validated protocol transaction that is a superset of
-/// a Bitcoin transaction. It includes additional metadata
-/// and captures all resulting state changes.
-pub struct ValidatedTransaction {
-    #[cfg_attr(feature = "bincode", bincode(with_serde))]
-    pub version: Version,
-    /// Txid cache
+/// A `TxChangeSet` captures all resulting state changes.
+pub struct TxChangeSet {
     #[cfg_attr(feature = "bincode", bincode(with_serde))]
     pub txid: Txid,
-    /// Block height or timestamp. Transaction cannot be included in a block until this height/time.
-    #[cfg_attr(feature = "bincode", bincode(with_serde))]
-    pub lock_time: absolute::LockTime,
     /// List of transaction inputs.
-    #[cfg_attr(feature = "serde", serde(rename = "vin"))]
-    pub input: Vec<TxInKind>,
+    pub spends: Vec<SpaceIn>,
     /// List of transaction outputs.
-    #[cfg_attr(feature = "serde", serde(rename = "vout"))]
-    pub output: Vec<TxOutKind>,
-    /// Meta outputs are not part of the actual transaction,
-    /// but they capture other state changes caused by it
-    #[cfg_attr(feature = "serde", serde(rename = "vmetaout"))]
-    pub meta_output: Vec<MetaOutKind>,
-}
-
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-#[cfg_attr(feature = "serde", serde(untagged))]
-pub enum TxInKind {
-    #[cfg_attr(feature = "serde", serde(rename = "coinout"))]
-    CoinIn(#[cfg_attr(feature = "bincode", bincode(with_serde))] TxIn),
-    #[cfg_attr(feature = "serde", serde(rename = "spaceout"))]
-    SpaceIn(SpaceIn),
+    pub creates: Vec<SpaceOut>,
+    /// Updates to outputs that are not part of the actual transaction such as bid
+    /// or "auctioned" outputs.
+    pub updates: Vec<UpdateOut>,
 }
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub struct SpaceIn {
-    #[cfg_attr(feature = "bincode", bincode(with_serde))]
-    #[cfg_attr(feature = "serde", serde(flatten))]
-    pub txin: TxIn,
+    pub n: usize,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub script_error: Option<ScriptError>,
 }
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-#[cfg_attr(feature = "serde", serde(untagged))]
-pub enum TxOutKind {
-    CoinOut(#[cfg_attr(feature = "bincode", bincode(with_serde))] TxOut),
-    SpaceOut(SpaceOut),
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case", tag = "type"))]
+pub enum UpdateKind {
+    Revoke(RevokeReason),
+    Rollout(RolloutDetails),
+    Bid,
 }
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-#[cfg_attr(feature = "serde", serde(untagged))]
-pub enum MetaOutKind {
-    ErrorOut(ErrorOut),
-    RolloutOut(RolloutOut),
-    SpaceOut(FullSpaceOut),
-}
-
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-pub struct RolloutOut {
-    #[cfg_attr(feature = "bincode", bincode(with_serde))]
-    pub outpoint: OutPoint,
-    #[cfg_attr(feature = "bincode", bincode(with_serde))]
-    pub bid_value: Amount,
-
+pub struct UpdateOut {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    pub spaceout: SpaceOut,
+    pub kind: UpdateKind,
+    pub output: FullSpaceOut,
 }
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-#[cfg_attr(feature = "serde", serde(tag = "action"))]
-pub enum ErrorOut {
-    #[cfg_attr(feature = "serde", serde(rename = "reject"))]
-    Reject(RejectParams),
-    #[cfg_attr(feature = "serde", serde(rename = "revoke"))]
-    Revoke(RevokeParams),
+pub struct RolloutDetails {
+    #[cfg_attr(feature = "bincode", bincode(with_serde))]
+    pub priority: Amount,
 }
 
 #[derive(Clone, Debug)]
@@ -115,11 +73,9 @@ pub enum ErrorOut {
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub struct RevokeParams {
     pub reason: RevokeReason,
-    #[cfg_attr(feature = "serde", serde(rename = "target"))]
-    pub spaceout: FullSpaceOut,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub struct RejectParams {
@@ -142,83 +98,63 @@ impl Validator {
         Self {}
     }
 
-    pub fn process(&self, height: u32, mut tx: PreparedTransaction) -> ValidatedTransaction {
+    pub fn process(&self, height: u32, tx: &Transaction, mut meta: TxContext) -> TxChangeSet {
         // Auctioned outputs could technically be spent in the same transaction
         // making the bid psbt unusable. We need to clear any spent ones
         // before proceeding with further validation
-        Self::clear_auctioned_spent(&mut tx);
+        Self::clear_auctioned_spent(tx, &mut meta);
 
-        let mut changeset = ValidatedTransaction {
-            txid: tx.txid,
-            version: tx.version,
-            lock_time: tx.lock_time,
-            input: Vec::with_capacity(tx.inputs.len()),
-            output: tx
-                .outputs
-                .into_iter()
-                .map(|out| TxOutKind::CoinOut(out))
-                .collect(),
-            meta_output: vec![],
+        let mut changeset = TxChangeSet {
+            txid: tx.compute_txid(),
+            spends: vec![],
+            creates: vec![],
+            updates: vec![],
         };
 
         let mut default_space_data = Vec::new();
         let mut space_data = BTreeMap::new();
         let mut reserve = false;
 
-        for (input_index, full_txin) in tx.inputs.into_iter().enumerate() {
-            match full_txin {
-                FullTxIn::FullSpaceIn(spacein) => {
-                    changeset.input.push(TxInKind::SpaceIn(SpaceIn {
-                        txin: spacein.input.clone(),
-                        script_error: None,
-                    }));
+        for fullspacein in meta.inputs.into_iter() {
+            changeset.spends.push(SpaceIn {
+                n: fullspacein.n,
+                script_error: None,
+            });
 
-                    // Process spends of existing space outputs
-                    self.process_spend(
-                        height,
-                        tx.version.0,
-                        &mut tx.auctioned_output,
-                        spacein.input,
-                        input_index as u32,
-                        spacein.sstxo,
-                        &mut changeset,
-                    );
+            // Process spends of existing space outputs
+            self.process_spend(
+                height,
+                tx,
+                &mut meta.auctioned_output,
+                fullspacein.n,
+                fullspacein.sstxo,
+                &mut changeset,
+            );
 
-                    // Process any space scripts
-                    if let Some(script) = spacein.script {
-                        if script.is_err() {
-                            match &mut changeset.input.last_mut().unwrap() {
-                                TxInKind::CoinIn(_) => {
-                                    // Do nothing
-                                }
-                                TxInKind::SpaceIn(spacein) => {
-                                    spacein.script_error = Some(script.unwrap_err());
-                                }
-                            }
-                        } else {
-                            let mut script = script.unwrap();
-                            if !script.reserve {
-                                if let Some(open) = script.open {
-                                    self.process_open(
-                                        height,
-                                        open,
-                                        &mut tx.auctioned_output,
-                                        &mut changeset,
-                                    );
-                                }
-                                if let Some(data) = script.default_sdata {
-                                    default_space_data = data;
-                                }
-                                space_data.append(&mut script.sdata);
-                            } else {
-                                // Script uses reserved op codes
-                                reserve = true;
-                            }
+            // Process any space scripts
+            if let Some(script) = fullspacein.script {
+                if script.is_err() {
+                    let last = changeset.spends.last_mut().unwrap();
+                    last.script_error = Some(script.unwrap_err());
+                } else {
+                    let mut script = script.unwrap();
+                    if !script.reserve {
+                        if let Some(open) = script.open {
+                            self.process_open(
+                                height,
+                                open,
+                                &mut meta.auctioned_output,
+                                &mut changeset,
+                            );
                         }
+                        if let Some(data) = script.default_sdata {
+                            default_space_data = data;
+                        }
+                        space_data.append(&mut script.sdata);
+                    } else {
+                        // Script uses reserved op codes
+                        reserve = true;
                     }
-                }
-                FullTxIn::CoinIn(coinin) => {
-                    changeset.input.push(TxInKind::CoinIn(coinin));
                 }
             }
         }
@@ -227,17 +163,10 @@ impl Validator {
         // then all space outputs with the transfer covenant must be marked as reserved
         // This does not have an effect on meta outputs
         if reserve {
-            for out in changeset.output.iter_mut() {
-                match out {
-                    TxOutKind::SpaceOut(spaceout) => {
-                        if let Some(space) = spaceout.space.as_mut() {
-                            if matches!(space.covenant, Covenant::Transfer { .. }) {
-                                space.covenant = Covenant::Reserved
-                            }
-                        }
-                    }
-                    TxOutKind::CoinOut(_) => {
-                        // do nothing
+            for out in changeset.creates.iter_mut() {
+                if let Some(space) = out.space.as_mut() {
+                    if matches!(space.covenant, Covenant::Transfer { .. }) {
+                        space.covenant = Covenant::Reserved
                     }
                 }
             }
@@ -245,57 +174,51 @@ impl Validator {
 
         // Set default space data if any
         if !default_space_data.is_empty() {
-            changeset.output.iter_mut().for_each(|output| match output {
-                TxOutKind::SpaceOut(spaceout) => match spaceout.space.as_mut() {
-                    None => {}
-                    Some(space) => match &mut space.covenant {
+            changeset.creates.iter_mut().for_each(|output| {
+                if let Some(space) = output.space.as_mut() {
+                    match &mut space.covenant {
                         Covenant::Transfer { data, .. } => {
                             *data = Some(default_space_data.clone());
                         }
                         _ => {}
-                    },
-                },
-                _ => {}
+                    }
+                }
             });
         }
 
         // Set space specific data
         if !space_data.is_empty() {
             for (key, value) in space_data.into_iter() {
-                match changeset.output.get_mut(key as usize) {
-                    None => {
-                        // do nothing
+                if let Some(spaceout) = changeset.creates.get_mut(key as usize) {
+                    if let Some(space) = spaceout.space.as_mut() {
+                        match &mut space.covenant {
+                            Covenant::Transfer { data, .. } => {
+                                *data = Some(value);
+                            }
+                            _ => {}
+                        }
                     }
-                    Some(output) => match output {
-                        TxOutKind::SpaceOut(spaceout) => match spaceout.space.as_mut() {
-                            None => {}
-                            Some(space) => match &mut space.covenant {
-                                Covenant::Transfer { data, .. } => {
-                                    *data = Some(value);
-                                }
-                                _ => {}
-                            },
-                        },
-                        _ => {}
-                    },
                 }
             }
         }
 
         // Check if any outputs should be tracked
-        if is_magic_lock_time(&changeset.lock_time) {
-            for output in changeset.output.iter_mut() {
-                match output {
-                    TxOutKind::CoinOut(txout) => {
-                        if txout.is_magic_output() {
-                            *output = TxOutKind::SpaceOut(SpaceOut {
-                                value: txout.value,
-                                script_pubkey: txout.script_pubkey.clone(),
+        if is_magic_lock_time(&tx.lock_time) {
+            for (n, output) in tx.output.iter().enumerate() {
+                match changeset.creates.iter().find(|x| x.n == n) {
+                    None => {
+                        if output.is_magic_output() {
+                            changeset.creates.push(SpaceOut {
+                                n,
+                                value: output.value,
+                                script_pubkey: output.script_pubkey.clone(),
                                 space: None,
                             })
                         }
                     }
-                    _ => {}
+                    Some(_) => {
+                        // already tracked
+                    }
                 }
             }
         }
@@ -306,27 +229,17 @@ impl Validator {
     pub fn rollout(
         &self,
         height: u32,
-        coinbase: Transaction,
+        coinbase: &Transaction,
         entries: Vec<FullSpaceOut>,
-    ) -> ValidatedTransaction {
+    ) -> TxChangeSet {
         assert!(coinbase.is_coinbase(), "expected a coinbase tx");
         assert!(entries.len() <= ROLLOUT_BATCH_SIZE, "bad rollout size");
 
-        let mut tx = ValidatedTransaction {
-            version: coinbase.version,
+        let mut tx = TxChangeSet {
             txid: coinbase.compute_txid(),
-            lock_time: coinbase.lock_time,
-            input: coinbase
-                .input
-                .into_iter()
-                .map(|input| TxInKind::CoinIn(input))
-                .collect(),
-            output: coinbase
-                .output
-                .into_iter()
-                .map(|out| TxOutKind::CoinOut(out))
-                .collect(),
-            meta_output: vec![],
+            spends: vec![],
+            creates: vec![],
+            updates: vec![],
         };
 
         for mut entry in entries {
@@ -351,11 +264,12 @@ impl Validator {
                 }
             };
 
-            tx.meta_output.push(MetaOutKind::RolloutOut(RolloutOut {
-                outpoint: entry.outpoint,
-                bid_value: rollout_bid,
-                spaceout: entry.spaceout,
-            }));
+            tx.updates.push(UpdateOut {
+                kind: UpdateKind::Rollout(RolloutDetails {
+                    priority: rollout_bid,
+                }),
+                output: entry,
+            });
         }
 
         tx
@@ -365,17 +279,18 @@ impl Validator {
     // this function checks for such spends and updates the prepared tx
     // accordingly
     #[inline]
-    fn clear_auctioned_spent(tx: &mut PreparedTransaction) {
-        if let Some(auctioned) = tx
+    fn clear_auctioned_spent(tx: &Transaction, meta: &mut TxContext) {
+        if let Some(auctioned) = meta
             .auctioned_output
             .as_ref()
             .and_then(|out| Some(out.bid_psbt.outpoint))
         {
-            if tx.inputs.iter().any(|input| match input {
-                FullTxIn::FullSpaceIn(prev) => prev.input.previous_output == auctioned,
-                FullTxIn::CoinIn(prev) => prev.previous_output == auctioned,
-            }) {
-                tx.auctioned_output.as_mut().unwrap().output = None;
+            if tx
+                .input
+                .iter()
+                .any(|input| input.previous_output == auctioned)
+            {
+                meta.auctioned_output.as_mut().unwrap().output = None;
             }
         }
     }
@@ -385,31 +300,34 @@ impl Validator {
         height: u32,
         open: OpOpenContext,
         auctiond: &mut Option<AuctionedOutput>,
-        changeset: &mut ValidatedTransaction,
+        changeset: &mut TxChangeSet,
     ) {
+        let spend_index = changeset
+            .spends
+            .iter()
+            .position(|s| s.n == open.input_index)
+            .expect("open must have an input index revealing the space in witness");
+
         let name = match open.spaceout {
             SpaceKind::ExistingSpace(mut prev) => {
                 let prev_space = prev.spaceout.space.as_mut().unwrap();
                 if !prev_space.is_expired(height) {
-                    changeset
-                        .meta_output
-                        .push(MetaOutKind::ErrorOut(ErrorOut::Reject(RejectParams {
-                            name: prev.spaceout.space.unwrap().name,
-                            reason: RejectReason::AlreadyExists,
-                        })));
+                    let reject = ScriptError::Reject(RejectParams {
+                        name: prev.spaceout.space.unwrap().name,
+                        reason: RejectReason::AlreadyExists,
+                    });
+                    changeset.spends[spend_index].script_error = Some(reject);
                     return;
                 }
 
                 // Revoke the previously expired space
-                changeset
-                    .meta_output
-                    .push(MetaOutKind::ErrorOut(ErrorOut::Revoke(RevokeParams {
-                        spaceout: FullSpaceOut {
-                            outpoint: prev.outpoint,
-                            spaceout: prev.spaceout.clone(),
-                        },
-                        reason: RevokeReason::Expired,
-                    })));
+                changeset.updates.push(UpdateOut {
+                    kind: UpdateKind::Revoke(RevokeReason::Expired),
+                    output: FullSpaceOut {
+                        txid: prev.txid,
+                        spaceout: prev.spaceout.clone(),
+                    },
+                });
                 prev.spaceout.space.unwrap().name
             }
             SpaceKind::NewSpace(name) => name,
@@ -417,24 +335,23 @@ impl Validator {
 
         let mut auctiond = match auctiond.take() {
             None => {
-                changeset
-                    .meta_output
-                    .push(MetaOutKind::ErrorOut(ErrorOut::Reject(RejectParams {
-                        name,
-                        reason: RejectReason::BidPSBT(BidPsbtReason::Required),
-                    })));
+                let reject = ScriptError::Reject(RejectParams {
+                    name,
+                    reason: RejectReason::BidPSBT(BidPsbtReason::Required),
+                });
+
+                changeset.spends[spend_index].script_error = Some(reject);
                 return;
             }
             Some(auctiond) => auctiond,
         };
 
         if auctiond.output.is_none() {
-            changeset
-                .meta_output
-                .push(MetaOutKind::ErrorOut(ErrorOut::Reject(RejectParams {
-                    name,
-                    reason: RejectReason::BidPSBT(BidPsbtReason::OutputSpent),
-                })));
+            let reject = ScriptError::Reject(RejectParams {
+                name,
+                reason: RejectReason::BidPSBT(BidPsbtReason::OutputSpent),
+            });
+            changeset.spends[spend_index].script_error = Some(reject);
             return;
         }
 
@@ -454,61 +371,54 @@ impl Validator {
         });
 
         let fullspaceout = FullSpaceOut {
-            outpoint: contract.outpoint,
+            txid: contract.outpoint.txid,
             spaceout: auctioned_spaceout,
         };
 
         if !fullspaceout.verify_bid_sig() {
-            changeset
-                .meta_output
-                .push(MetaOutKind::ErrorOut(ErrorOut::Reject(RejectParams {
-                    name: fullspaceout.spaceout.space.unwrap().name,
-                    reason: RejectReason::BidPSBT(BidPsbtReason::BadSignature),
-                })));
+            let reject = ScriptError::Reject(RejectParams {
+                name: fullspaceout.spaceout.space.unwrap().name,
+                reason: RejectReason::BidPSBT(BidPsbtReason::BadSignature),
+            });
+            changeset.spends[spend_index].script_error = Some(reject);
             return;
         }
 
-        changeset
-            .meta_output
-            .push(MetaOutKind::SpaceOut(fullspaceout));
+        changeset.updates.push(UpdateOut{
+            kind: UpdateKind::Bid,
+            output: fullspaceout,
+        });
     }
 
     /// Auctioned output may already be representing another space,
     /// so we'll need to revoke it, and then we could attach this
     /// any new space to the output
     #[inline]
-    fn detach_existing_space(
-        auctioned: &mut AuctionedOutput,
-        changeset: &mut ValidatedTransaction,
-    ) {
+    fn detach_existing_space(auctioned: &mut AuctionedOutput, changeset: &mut TxChangeSet) {
         if let Some(spaceout) = &auctioned.output {
             if spaceout.space.is_none() {
                 return;
             }
-
-            changeset
-                .meta_output
-                .push(MetaOutKind::ErrorOut(ErrorOut::Revoke(RevokeParams {
-                    spaceout: FullSpaceOut {
-                        outpoint: auctioned.bid_psbt.outpoint,
-                        spaceout: spaceout.clone(),
-                    },
-                    reason: RevokeReason::BadSpend,
-                })));
+            changeset.updates.push(UpdateOut {
+                output: FullSpaceOut {
+                    txid: auctioned.bid_psbt.outpoint.txid,
+                    spaceout: spaceout.clone(),
+                },
+                kind: UpdateKind::Revoke(RevokeReason::BadSpend),
+            });
         }
     }
 
-    /// All spends with an spent spaces transaction output must be
+    /// All spends with a spent spaces transaction output must be
     /// marked as spent as this function only does additional processing for spends of spaces
     fn process_spend(
         &self,
         height: u32,
-        tx_version: i32,
+        tx: &Transaction,
         auctioned: &mut Option<AuctionedOutput>,
-        input: TxIn,
-        input_index: u32,
+        input_index: usize,
         stxo: SSTXO,
-        changeset: &mut ValidatedTransaction,
+        changeset: &mut TxChangeSet,
     ) {
         let spaceout = &stxo.previous_output;
         let space = match &spaceout.space {
@@ -519,16 +429,15 @@ impl Validator {
             Some(space) => space,
         };
 
+        let input = tx.input.get(input_index).expect("input");
         if space.is_expired(height) {
-            changeset
-                .meta_output
-                .push(MetaOutKind::ErrorOut(ErrorOut::Revoke(RevokeParams {
-                    spaceout: FullSpaceOut {
-                        outpoint: input.previous_output,
-                        spaceout: spaceout.clone(),
-                    },
-                    reason: RevokeReason::Expired,
-                })));
+            changeset.updates.push(UpdateOut {
+                output: FullSpaceOut {
+                    txid: input.previous_output.txid,
+                    spaceout: spaceout.clone(),
+                },
+                kind: UpdateKind::Revoke(RevokeReason::Expired),
+            });
             return;
         }
 
@@ -540,9 +449,8 @@ impl Validator {
             } => {
                 self.process_bid_spend(
                     height,
-                    tx_version,
+                    tx,
                     auctioned,
-                    input,
                     input_index,
                     stxo,
                     total_burned,
@@ -553,7 +461,7 @@ impl Validator {
             Covenant::Transfer { .. } => {
                 self.process_transfer(
                     height,
-                    input,
+                    tx,
                     input_index,
                     stxo.previous_output.clone(),
                     space.data_owned(),
@@ -561,8 +469,10 @@ impl Validator {
                 );
             }
             Covenant::Reserved => {
-                // Treat it as a coin spend, so it remains locked in our UTXO set
-                changeset.input[input_index as usize] = TxInKind::CoinIn(input);
+                // Keep it unspent so it remains locked in our UTXO set
+                if let Some(pos) = changeset.spends.iter().position(|i| i.n == input_index) {
+                    changeset.spends.remove(pos);
+                }
             }
         }
     }
@@ -570,57 +480,51 @@ impl Validator {
     fn process_bid_spend(
         &self,
         height: u32,
-        tx_version: i32,
+        tx: &Transaction,
         auctioned: &mut Option<AuctionedOutput>,
-        input: TxIn,
-        input_index: u32,
+        input_index: usize,
         stxo: SSTXO,
         total_burned: Amount,
         claim_height: Option<u32>,
-        changeset: &mut ValidatedTransaction,
+        changeset: &mut TxChangeSet,
     ) {
+        let input = tx.input.get(input_index as usize).expect("input");
         let mut spaceout = stxo.previous_output;
         let space_ref = spaceout.space.as_mut().unwrap();
         // Handle bid spends
-        if space_ref.is_bid_spend(tx_version, &input) {
+        if space_ref.is_bid_spend(tx.version, input) {
             // Bid spends must have an auctioned output
             let auctioned_output = auctioned.take();
             if auctioned_output.is_none() {
-                changeset
-                    .meta_output
-                    .push(MetaOutKind::ErrorOut(ErrorOut::Revoke(RevokeParams {
-                        spaceout: FullSpaceOut {
-                            outpoint: input.previous_output,
-                            spaceout,
-                        },
-                        reason: RevokeReason::BidPsbt(BidPsbtReason::Required),
-                    })));
+                changeset.updates.push(UpdateOut {
+                    output: FullSpaceOut {
+                        txid: input.previous_output.txid,
+                        spaceout,
+                    },
+                    kind: UpdateKind::Revoke(RevokeReason::BidPsbt(BidPsbtReason::Required)),
+                });
                 return;
             }
             let auctioned_output = auctioned_output.unwrap();
             if auctioned_output.output.is_none() {
-                changeset
-                    .meta_output
-                    .push(MetaOutKind::ErrorOut(ErrorOut::Revoke(RevokeParams {
-                        spaceout: FullSpaceOut {
-                            outpoint: input.previous_output,
-                            spaceout,
-                        },
-                        reason: RevokeReason::BidPsbt(BidPsbtReason::OutputSpent),
-                    })));
+                changeset.updates.push(UpdateOut {
+                    output: FullSpaceOut {
+                        txid: input.previous_output.txid,
+                        spaceout,
+                    },
+                    kind: UpdateKind::Revoke(RevokeReason::BidPsbt(BidPsbtReason::OutputSpent)),
+                });
                 return;
             }
 
             if auctioned_output.bid_psbt.burn_amount == Amount::ZERO {
-                changeset
-                    .meta_output
-                    .push(MetaOutKind::ErrorOut(ErrorOut::Revoke(RevokeParams {
-                        spaceout: FullSpaceOut {
-                            outpoint: input.previous_output,
-                            spaceout,
-                        },
-                        reason: RevokeReason::BidPsbt(BidPsbtReason::LowBidAmount),
-                    })));
+                changeset.updates.push(UpdateOut {
+                    output: FullSpaceOut {
+                        txid: input.previous_output.txid,
+                        spaceout,
+                    },
+                    kind: UpdateKind::Revoke(RevokeReason::BidPsbt(BidPsbtReason::LowBidAmount)),
+                });
                 return;
             }
 
@@ -640,100 +544,103 @@ impl Validator {
                 claim_height,
             };
 
+            let auctioned_spaceout = auctioned_output.output.unwrap();
+            assert_eq!(
+                auctioned_spaceout.n,
+                auctioned_output.bid_psbt.outpoint.vout as usize
+            );
             let mut fullspaceout = FullSpaceOut {
-                outpoint: auctioned_output.bid_psbt.outpoint,
-                spaceout: auctioned_output.output.unwrap(),
+                txid: auctioned_output.bid_psbt.outpoint.txid,
+                spaceout: auctioned_spaceout,
             };
             fullspaceout.spaceout.space = Some(spaceout.space.unwrap());
 
             if !fullspaceout.verify_bid_sig() {
-                changeset
-                    .meta_output
-                    .push(MetaOutKind::ErrorOut(ErrorOut::Revoke(RevokeParams {
-                        spaceout: fullspaceout,
-                        reason: RevokeReason::BidPsbt(BidPsbtReason::BadSignature),
-                    })));
+                changeset.updates.push(UpdateOut {
+                    output: fullspaceout,
+                    kind: UpdateKind::Revoke(RevokeReason::BidPsbt(BidPsbtReason::BadSignature)),
+                });
                 return;
             }
 
-            changeset
-                .meta_output
-                .push(MetaOutKind::SpaceOut(fullspaceout));
+            changeset.updates.push(UpdateOut {
+                output: fullspaceout,
+                kind: UpdateKind::Bid,
+            });
             return;
         }
 
         // Handle non-bid spends:
         // Check register attempt before claim height
         if claim_height.is_none() || *claim_height.as_ref().unwrap() > height {
-            changeset
-                .meta_output
-                .push(MetaOutKind::ErrorOut(ErrorOut::Revoke(RevokeParams {
-                    spaceout: FullSpaceOut {
-                        outpoint: input.previous_output,
-                        spaceout,
-                    },
-                    reason: RevokeReason::PrematureClaim,
-                })));
+            changeset.updates.push(UpdateOut {
+                output: FullSpaceOut {
+                    txid: input.previous_output.txid,
+                    spaceout,
+                },
+                kind: UpdateKind::Revoke(RevokeReason::PrematureClaim),
+            });
             return;
         }
 
         // Registration spend:
-        self.process_transfer(height, input, input_index, spaceout, None, changeset);
+        self.process_transfer(height, tx, input_index, spaceout, None, changeset);
     }
 
     fn process_transfer(
         &self,
         height: u32,
-        input: TxIn,
-        input_index: u32,
-        spaceout: SpaceOut,
+        tx: &Transaction,
+        input_index: usize,
+        mut spaceout: SpaceOut,
         existing_data: Option<Vec<u8>>,
-        changeset: &mut ValidatedTransaction,
+        changeset: &mut TxChangeSet,
     ) {
+        let input = tx.input.get(input_index).expect("input");
         let output_index = input_index + 1;
-        let output = changeset.output.get_mut(output_index as usize);
+        let output = tx.output.get(output_index);
         match output {
+            None => {
+                // No corresponding output found
+                changeset.updates.push(UpdateOut {
+                    output: FullSpaceOut {
+                        txid: input.previous_output.txid,
+                        spaceout,
+                    },
+                    kind: UpdateKind::Revoke(RevokeReason::BadSpend),
+                });
+            }
             Some(output) => {
-                let txout = match output {
-                    TxOutKind::CoinOut(txout) => txout.clone(),
-                    _ => {
-                        changeset
-                            .meta_output
-                            .push(MetaOutKind::ErrorOut(ErrorOut::Revoke(RevokeParams {
-                                spaceout: FullSpaceOut {
-                                    outpoint: input.previous_output,
-                                    spaceout,
-                                },
-                                reason: RevokeReason::BadSpend,
-                            })));
-                        return;
-                    }
-                };
+                // check if there's an existing space output created by this transaction
+                // representing another space somehow (should never be possible anyway?)
+                if changeset
+                    .creates
+                    .iter()
+                    .position(|x| x.n == input_index)
+                    .is_some()
+                {
+                    changeset.updates.push(UpdateOut {
+                        output: FullSpaceOut {
+                            txid: input.previous_output.txid,
+                            spaceout,
+                        },
+                        kind: UpdateKind::Revoke(RevokeReason::BadSpend),
+                    });
+                    return;
+                }
+
+                spaceout.n = output_index;
+                spaceout.value = output.value;
+                spaceout.script_pubkey = output.script_pubkey.clone();
 
                 let mut space = spaceout.space.unwrap();
                 space.covenant = Covenant::Transfer {
                     expire_height: height + RENEWAL_INTERVAL,
                     data: existing_data,
                 };
-
-                *output = TxOutKind::SpaceOut(SpaceOut {
-                    value: txout.value,
-                    script_pubkey: txout.script_pubkey,
-                    space: Some(space),
-                });
+                spaceout.space = Some(space);
+                changeset.creates.push(spaceout);
             }
-            None => {
-                // No corresponding output found
-                changeset
-                    .meta_output
-                    .push(MetaOutKind::ErrorOut(ErrorOut::Revoke(RevokeParams {
-                        spaceout: FullSpaceOut {
-                            outpoint: input.previous_output,
-                            spaceout,
-                        },
-                        reason: RevokeReason::BadSpend,
-                    })));
-            }
-        };
+        }
     }
 }

--- a/protocol/src/validate.rs
+++ b/protocol/src/validate.rs
@@ -1,4 +1,5 @@
 use alloc::{collections::btree_map::BTreeMap, vec, vec::Vec};
+
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};
 use bitcoin::{Amount, OutPoint, Transaction, Txid};
@@ -7,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     constants::{AUCTION_DURATION, AUCTION_EXTENSION_ON_BID, RENEWAL_INTERVAL, ROLLOUT_BATCH_SIZE},
-    prepare::{is_magic_lock_time, AuctionedOutput, TxContext, TrackableOutput, SSTXO},
+    prepare::{is_magic_lock_time, AuctionedOutput, TrackableOutput, TxContext, SSTXO},
     script::{OpOpenContext, ScriptError, SpaceKind},
     sname::SName,
     BidPsbtReason, Covenant, FullSpaceOut, RejectReason, RevokeReason, Space, SpaceOut,
@@ -384,7 +385,7 @@ impl Validator {
             return;
         }
 
-        changeset.updates.push(UpdateOut{
+        changeset.updates.push(UpdateOut {
             kind: UpdateKind::Bid,
             output: fullspaceout,
         });

--- a/protocol/src/validate.rs
+++ b/protocol/src/validate.rs
@@ -98,11 +98,11 @@ impl Validator {
         Self {}
     }
 
-    pub fn process(&self, height: u32, tx: &Transaction, mut meta: TxContext) -> TxChangeSet {
+    pub fn process(&self, height: u32, tx: &Transaction, mut ctx: TxContext) -> TxChangeSet {
         // Auctioned outputs could technically be spent in the same transaction
         // making the bid psbt unusable. We need to clear any spent ones
         // before proceeding with further validation
-        Self::clear_auctioned_spent(tx, &mut meta);
+        Self::clear_auctioned_spent(tx, &mut ctx);
 
         let mut changeset = TxChangeSet {
             txid: tx.compute_txid(),
@@ -115,7 +115,7 @@ impl Validator {
         let mut space_data = BTreeMap::new();
         let mut reserve = false;
 
-        for fullspacein in meta.inputs.into_iter() {
+        for fullspacein in ctx.inputs.into_iter() {
             changeset.spends.push(SpaceIn {
                 n: fullspacein.n,
                 script_error: None,
@@ -125,7 +125,7 @@ impl Validator {
             self.process_spend(
                 height,
                 tx,
-                &mut meta.auctioned_output,
+                &mut ctx.auctioned_output,
                 fullspacein.n,
                 fullspacein.sstxo,
                 &mut changeset,
@@ -143,7 +143,7 @@ impl Validator {
                             self.process_open(
                                 height,
                                 open,
-                                &mut meta.auctioned_output,
+                                &mut ctx.auctioned_output,
                                 &mut changeset,
                             );
                         }

--- a/wallet/src/builder.rs
+++ b/wallet/src/builder.rs
@@ -182,9 +182,9 @@ impl<'a, Cs: CoinSelectionAlgorithm> TxBuilderSpacesUtils<'a, Cs> for TxBuilder<
         };
 
         let tap_key_spend_weight = 66;
-        self.version(BID_PSBT_TX_VERSION);
+        self.version(BID_PSBT_TX_VERSION.0);
         self.add_foreign_utxo_with_sequence(
-            info.outpoint,
+            info.outpoint(),
             input,
             tap_key_spend_weight,
             BID_PSBT_INPUT_SEQUENCE,
@@ -295,7 +295,14 @@ impl<'a, Cs: CoinSelectionAlgorithm> TxBuilderSpacesUtils<'a, Cs> for TxBuilder<
                 spend_input
                     .proprietary
                     .insert(SpacesWallet::spaces_signer("tbs"), Vec::new());
-                self.add_foreign_utxo(request.space.outpoint, spend_input, 66)?;
+                self.add_foreign_utxo(
+                    OutPoint {
+                        txid: request.space.txid,
+                        vout: request.space.spaceout.n as u32,
+                    },
+                    spend_input,
+                    66,
+                )?;
                 self.add_recipient(
                     request.recipient.script_pubkey(),
                     request.space.spaceout.value,


### PR DESCRIPTION
This adds `getblockmeta` and `gettxmeta` (helper)  closes #14 and closes #18.

New structure looks like the one we discussed [here](https://github.com/spacesprotocol/spaced/issues/18#issuecomment-2379634362)


## New format

### Rejects are now script errors

For example, calling OP_OPEN on a name that already exists will just be a script error (this used to be in vmetaout):

```
{
  "txid": "b38982ddd21abce52eb17042afe324944a91a98fda2af96370b8aa8459c4f848",
  "spends": [
    {
      "n": 1,
      "script_error": {
        "type": "reject",
        "name": "@artfuldev",
        "reason": "already_exists"
      }
    }
  ],
  "creates": [],
  "updates": []
}
```

### Updates have a type: `bid`, `rollout` or `revoke`

All updates have an `output` object which links to the external output being affected by this transaction


#### Type `bid`

Updates to bid outputs look like this

```json
"updates": [
{
  "type": "bid",
  "output": {
    "txid": "a9226ee6316b88737776fab48824f9694c184bcc75577c7844bec2363613a820",
    "n": 1,
    "name": "@bitcoin",
    "covenant": {
      "type": "bid",
      "burn_increment": 223,
      "signature": "aa6e6b5ecf6085cdbfffd0c7907418d4f5a0da532eaa8309d0e0831afb02f47d19edbb8ee30711e7a54f062ce9238bf9f56500cdc31b9561900ba5f2b29d2a28",
      "total_burned": 3000,
      "claim_height": 40489
    },
    "value": 662,
    "script_pubkey": "5120396909d29e4d68464d51b7009be7e2ca26eb5d8122e1f3b32a668b11f031144a"
  }
}]
```


#### Type`rollout`

```json
"updates": [
{
  "type": "rollout",
  "priority": 1000,
  "output": {
    "txid": "4ac2ba3c5955273eef077693446a5065bb3e6c4fe5e6d18f905a0310757ae04f",
    "n": 1,
    "name": "@911",
    "covenant": {
      "type": "bid",
      "burn_increment": 1000,
      "signature": "3f94a98b1bfcf03a50af9dc92ab94c9380826b036c7be03ba4be33d043a50fa8653341c8fd27ca13fb71f7832b16ed13ea63a527c5426877d915141498dffe05",
      "total_burned": 1000,
      "claim_height": 50689
    },
    "value": 662,
    "script_pubkey": "5120cc83e77e4718e58761d4f37082d5434f13fe9d29f3dd37c0c1ad2a26c91e61ad"
  }
}]
```

#### Type `revoke`

Updates revoking an output look like this:

```json
"updates": [
{
  "type": "revoke",
  "revoke_reason": "bid_psbt",
  "bid_psbt_reason": "low_bid_amount",
  "output": {
    "txid": "45e62540138ff1877dd04a53a62ff33eb69ec9ffaab216d92a5ce47fd4441f77",
    "n": 1,
    "name": "@k",
    "covenant": {
      "type": "bid",
      "burn_increment": 1000,
      "signature": "38808af35e6413bc3258b20ffb146acb570bd849706562b742293c0769bf2856d4aac4c441964deee71458834c1a1b937e4d58b3cfbcc7d01e1a1a47e3d519d6",
      "total_burned": 1000,
      "claim_height": 50977
    },
    "value": 662,
    "script_pubkey": "512099cdda46140ef48b5d144ca8b3c62303bb13aba73a7fb27e79bfac3f1235e7d2"
  }
}
]
```

This one provides a bit more detailed error for bid psbt due to the nested rust enums and how they appear as json.

Will merge this after some additional testing. Any thoughts @randomlogin ? do you want to give this PR a try in the meantime?