### PR TITLE
Update json format for bid psbt errors

### DIFF
--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -117,41 +117,47 @@ pub enum Covenant {
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[cfg_attr(
     feature = "serde",
-    serde(rename_all = "snake_case", tag = "revoke_reason")
+    serde(rename_all = "snake_case", tag = "reason")
 )]
 pub enum RevokeReason {
-    BidPsbt(BidPsbtReason),
     /// Space was prematurely spent during the auctions phase
     PrematureClaim,
     /// Space output was spent either by spending it directly
     /// Space was transferred without following Input N => Output N+1 rule
     BadSpend,
     Expired,
+    #[cfg_attr(feature = "serde", serde(untagged))]
+    BidPsbt(BidPsbtReason)
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, Eq)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
-    serde(rename_all = "snake_case")
+    serde(rename_all = "snake_case", tag="reason")
 )]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub enum RejectReason {
     AlreadyExists,
-    BidPSBT(BidPsbtReason),
+    #[cfg_attr(feature = "serde", serde(untagged))]
+    BidPsbt(BidPsbtReason),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
-    serde(rename_all = "snake_case", tag = "bid_psbt_reason")
+    serde(tag = "reason")
 )]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub enum BidPsbtReason {
+    #[cfg_attr(feature = "serde", serde(rename = "bid_psbt_required"))]
     Required,
+    #[cfg_attr(feature = "serde", serde(rename = "bid_psbt_low_bid_amount"))]
     LowBidAmount,
+    #[cfg_attr(feature = "serde", serde(rename = "bid_psbt_bad_signature"))]
     BadSignature,
+    #[cfg_attr(feature = "serde", serde(rename = "bid_psbt_output_spent"))]
     OutputSpent,
 }
 

--- a/protocol/src/validate.rs
+++ b/protocol/src/validate.rs
@@ -82,6 +82,8 @@ pub struct RevokeParams {
 pub struct RejectParams {
     #[cfg_attr(feature = "bincode", bincode(with_serde))]
     pub name: SName,
+
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub reason: RejectReason,
 }
 
@@ -338,7 +340,7 @@ impl Validator {
             None => {
                 let reject = ScriptError::Reject(RejectParams {
                     name,
-                    reason: RejectReason::BidPSBT(BidPsbtReason::Required),
+                    reason: RejectReason::BidPsbt(BidPsbtReason::Required),
                 });
 
                 changeset.spends[spend_index].script_error = Some(reject);
@@ -350,7 +352,7 @@ impl Validator {
         if auctiond.output.is_none() {
             let reject = ScriptError::Reject(RejectParams {
                 name,
-                reason: RejectReason::BidPSBT(BidPsbtReason::OutputSpent),
+                reason: RejectReason::BidPsbt(BidPsbtReason::OutputSpent),
             });
             changeset.spends[spend_index].script_error = Some(reject);
             return;
@@ -379,7 +381,7 @@ impl Validator {
         if !fullspaceout.verify_bid_sig() {
             let reject = ScriptError::Reject(RejectParams {
                 name: fullspaceout.spaceout.space.unwrap().name,
-                reason: RejectReason::BidPSBT(BidPsbtReason::BadSignature),
+                reason: RejectReason::BidPsbt(BidPsbtReason::BadSignature),
             });
             changeset.spends[spend_index].script_error = Some(reject);
             return;


### PR DESCRIPTION
Should look like this concatenated instead of the separate "bid_psbt_reason" field which looked inconsistent with rejects vs revokes

reject

```json
{
  "n": 1,
  "script_error": {
    "type": "reject",
    "name": "@tap4",
    "reason": "bid_psbt_output_spent"
  }
}
```

revoke

```json
{
  "type": "revoke",
  "reason": "bid_psbt_output_spent",
  "output": {
    "txid": "ef1c24f8384fbf7f0a7e9da88a25ee5e45e3a87e7032abd682171a3f545ee26d",
    "n": 1,
    "name": "@town",
    "covenant": {
      "type": "bid",
      "burn_increment": 1000,
      "signature": "594f7132b6a0b13654f440e85dcc8d676c768b3a485446b60fa44389a26dff721b13c148a0e4d39cf530efad86cba295329d5571c42fd46e1ccf81e015d86400",
      "total_burned": 1000,
      "claim_height": 50833
    },
    "value": 662,
    "script_pubkey": "5120eef9e4b2a75e2c01c79b80faf79b763bda9aae953621fdf97bcbae490e38e64f"
  }
}
```


revoke non bid psbt error


```json
{
  "type": "revoke",
  "reason": "premature_claim",
  "output": {
    "txid": "be3386da6ebb1c036ec8b0d28b52cfd38bc23e442642a1a8b73f16466391ee61",
    "n": 1,
    "name": "@tap3",
    "covenant": {
      "type": "bid",
      "burn_increment": 1000,
      "signature": "d34f49ee2fe69c82aff08252c0e6f83adc318297250c5d0d4a9edc8032cfbe009893c8a900d8e5a2d8778641885d2b6ca633876af5a4d3522069225c95f5fbc5",
      "total_burned": 1000,
      "claim_height": null
    },
    "value": 662,
    "script_pubkey": "5120ebe2a13988500badbb1268a18b5954604baef384a8291cf0c361df2437cb7ea7"
  }
}
```